### PR TITLE
✨ fix(schema): set SupervisorValidationStatus to NOT NULL and default pending

### DIFF
--- a/app/schema/create.sql
+++ b/app/schema/create.sql
@@ -55,7 +55,7 @@ CREATE TABLE [dbo].[Achievement] (
     [DocumentationFile]          VARCHAR(255) NOT NULL,
     [PosterFile]                 VARCHAR(255) NOT NULL,
     [CompetitionPoints]          DECIMAL      NOT NULL, -- SUM of [CompetitionLevel] and [CompetitionRank]
-    [SupervisorValidationStatus] VARCHAR(20)  NULL,     -- NULL/PENDING/APPROVED/REJECTED
+    [SupervisorValidationStatus] VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
     [SupervisorValidationDate]   DATETIME     NULL,     -- When supervisor validated
     [SupervisorValidationNote]   TEXT         NULL,     -- Supervisor feedback/notes
     [AdminValidationStatus]      VARCHAR(20)  NOT NULL DEFAULT 'PENDING',


### PR DESCRIPTION
### Pull Request Description

#### Title
✨ fix(schema): set SupervisorValidationStatus to NOT NULL and default pending

#### Summary
This pull request introduces a change to the database schema by updating the `SupervisorValidationStatus` field. The field is now set to NOT NULL, ensuring that it always contains a value. Additionally, a default value of 'pending' is assigned to this field, which will be applied to new entries where no specific value is provided.

#### Changes Made
- Altered the `SupervisorValidationStatus` column to be NOT NULL.
- Set a default value of 'pending' for the `SupervisorValidationStatus` field.

This enhancement aims to improve data integrity and ensure that the validation status is always available for supervisors, thereby providing a clearer context for record management.